### PR TITLE
execute_process: Don't close all file descriptors

### DIFF
--- a/docs/process_utils.rst
+++ b/docs/process_utils.rst
@@ -30,6 +30,15 @@ In addtion to these functions, there is a utility function for getting the corre
 
 .. autofunction:: osrf_pycommon.process_utils.get_loop
 
+Treatment of File Descriptors
+-----------------------------
+
+Unlike ``subprocess.Popen``, all of the ``process_utils`` functions behave the same way on Python versions 2.7 through 3.4, and they do not close `inheritable <https://docs.python.org/3.4/library/os.html#fd-inheritance>`. file descriptors before starting subprocesses. This is equivalent to passing ``close_fds=False`` to ``subprocess.Popen`` on all Python versions.
+
+In Python 3.2, the ``subprocess.Popen`` default for the ``close_fds`` option changed from ``False`` to ``True`` so that file descriptors opened by the parent process were closed before spawning the child process. In Python 3.4, `PEP 0446 <https://www.python.org/dev/peps/pep-0446/>`_ additionally made it so even when ``close_fds=False`` file descriptors which are `non-inheritable <https://docs.python.org/3.4/library/os.html#fd-inheritance>`_ are still closed before spawning the subprocess.
+
+If you want to be able to pass file descriptors to subprocesses in Python 3.4 or higher, you will need to make sure they are `inheritable <https://docs.python.org/3.4/library/os.html#fd-inheritance>`.
+
 Synchronous Process Utilities
 -----------------------------
 

--- a/osrf_pycommon/process_utils/async_execute_process_asyncio.py
+++ b/osrf_pycommon/process_utils/async_execute_process_asyncio.py
@@ -41,11 +41,11 @@ def _async_execute_process_nopty(
     if shell is True:
         transport, protocol = yield from loop.subprocess_shell(
             protocol_class, " ".join(cmd), cwd=cwd, env=env,
-            stderr=stderr)
+            stderr=stderr, close_fds=False)
     else:
         transport, protocol = yield from loop.subprocess_exec(
             protocol_class, *cmd, cwd=cwd, env=env,
-            stderr=stderr)
+            stderr=stderr, close_fds=False)
     return transport, protocol
 
 
@@ -71,11 +71,11 @@ if has_pty:
         if shell is True:
             transport, protocol = yield from loop.subprocess_shell(
                 protocol_factory, " ".join(cmd), cwd=cwd, env=env,
-                stdout=stdout_slave, stderr=stderr_slave)
+                stdout=stdout_slave, stderr=stderr_slave, close_fds=False)
         else:
             transport, protocol = yield from loop.subprocess_exec(
                 protocol_factory, *cmd, cwd=cwd, env=env,
-                stdout=stdout_slave, stderr=stderr_slave)
+                stdout=stdout_slave, stderr=stderr_slave, close_fds=False)
 
         # Close our copies of the slaves,
         # the child's copy of the slave remain open until it terminates

--- a/osrf_pycommon/process_utils/async_execute_process_trollius.py
+++ b/osrf_pycommon/process_utils/async_execute_process_trollius.py
@@ -43,11 +43,11 @@ def _async_execute_process_nopty(
     if shell is True:
         transport, protocol = yield From(loop.subprocess_shell(
             protocol_class, " ".join(cmd), cwd=cwd, env=env,
-            stderr=stderr))
+            stderr=stderr, close_fds=False))
     else:
         transport, protocol = yield From(loop.subprocess_exec(
             protocol_class, *cmd, cwd=cwd, env=env,
-            stderr=stderr))
+            stderr=stderr, close_fds=False))
     raise Return(transport, protocol)
 
 
@@ -73,11 +73,11 @@ if has_pty:
         if shell is True:
             transport, protocol = yield From(loop.subprocess_shell(
                 protocol_factory, " ".join(cmd), cwd=cwd, env=env,
-                stdout=stdout_slave, stderr=stderr_slave))
+                stdout=stdout_slave, stderr=stderr_slave, close_fds=False))
         else:
             transport, protocol = yield From(loop.subprocess_exec(
                 protocol_factory, *cmd, cwd=cwd, env=env,
-                stdout=stdout_slave, stderr=stderr_slave))
+                stdout=stdout_slave, stderr=stderr_slave, close_fds=False))
 
         # Close our copies of the slaves,
         # the child's copy of the slave remain open until it terminates

--- a/osrf_pycommon/process_utils/execute_process_nopty.py
+++ b/osrf_pycommon/process_utils/execute_process_nopty.py
@@ -131,11 +131,11 @@ def _execute_process_nopty(cmd, cwd, env, shell, stderr_to_stdout=True):
     if stderr_to_stdout:
         p = Popen(cmd,
                   stdin=PIPE, stdout=PIPE, stderr=STDOUT,
-                  cwd=cwd, env=env, shell=shell)
+                  cwd=cwd, env=env, shell=shell, close_fds=False)
     else:
         p = Popen(cmd,
                   stdin=PIPE, stdout=PIPE, stderr=PIPE,
-                  cwd=cwd, env=env, shell=shell)
+                  cwd=cwd, env=env, shell=shell, close_fds=False)
 
     # Left over data from read which isn't a complete line yet
     left_overs = {p.stdout: b'', p.stderr: b''}

--- a/osrf_pycommon/process_utils/execute_process_pty.py
+++ b/osrf_pycommon/process_utils/execute_process_pty.py
@@ -40,7 +40,7 @@ def _execute_process_pty(cmd, cwd, env, shell, stderr_to_stdout=True):
                 p = Popen(
                     cmd,
                     stdin=stdout_slave, stdout=stderr_slave, stderr=STDOUT,
-                    cwd=cwd, env=env, shell=shell)
+                    cwd=cwd, env=env, shell=shell, close_fds=False)
             except OSError as exc:
                 # This can happen if a file you are trying to execute is being
                 # written to simultaneously on Linux


### PR DESCRIPTION
In Python 3.2, `close_fds` defaults to `True` whereas in Python 2.7 it defaulted to `False`. This breaks support for passing file descriptors to child processes in Python 3.2, which is required to support the GNU Make jobserver in catkin_tools (see https://github.com/catkin/catkin_tools/issues/208)

For more info, see here: https://docs.python.org/3.2/library/subprocess.html#popen-constructor

I understand that this option could be exposed to the `osrf_pycommon` API, but this PR unifies behavior between Python 2 and Python 3.

Note that while leaking file descriptors is bad, in Python 3.4 all file descriptors were made non-inheritable by default, so they still need to be explicitly flagged to be passed so subprocesses. 

For more info on this, see here: http://legacy.python.org/dev/peps/pep-0446/