### PR TITLE
fix to work with flake8 >= 2.5

### DIFF
--- a/tests/test_code_format.py
+++ b/tests/test_code_format.py
@@ -8,7 +8,11 @@ def test_flake8():
     report = flake8style.options.report
     report.start()
     this_dir = os.path.dirname(os.path.abspath(__file__))
-    flake8style.input_dir(os.path.join(this_dir, '..', 'osrf_pycommon'))
+    try:
+        input_dir = flake8style.input_dir
+    except AttributeError:
+        input_dir = flake8style._styleguide.input_dir
+    input_dir(os.path.join(this_dir, '..', 'osrf_pycommon'))
     report.stop()
     assert report.total_errors == 0, \
         ("Found '{0}' code style errors (and warnings)."


### PR DESCRIPTION
Due to the following change: https://gitlab.com/pycqa/flake8/commit/1c6c1f51163784005dac358d60ecb8781d726151

http://ci.ros2.org/job/ros2_batch_ci_linux/490/testReport/tests/test_code_format/test_flake8/