### PR TITLE
make execute_process_pty.py importable on Windows to work with --cover-inclusive

### DIFF
--- a/osrf_pycommon/process_utils/execute_process_pty.py
+++ b/osrf_pycommon/process_utils/execute_process_pty.py
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 import os
-import pty
+try:
+    import pty
+except ImportError:
+    # to support --cover-inclusive on Windows
+    if os.name not in ['nt']:
+        raise
 import time
 
 from subprocess import Popen


### PR DESCRIPTION
Related to #15.

Before: http://ci.ros2.org/job/ci_windows_opensplice/694/testReport/nose.failure/Failure/runTest/
After: http://ci.ros2.org/job/ci_windows_opensplice/696/