### PR TITLE
add osrf_pycommon.vendor.trollius_helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+trollius-*.zip

--- a/osrf_pycommon/process_utils/async_execute_process.py
+++ b/osrf_pycommon/process_utils/async_execute_process.py
@@ -81,6 +81,8 @@ That same example using :py:mod:`trollius` would look like this:
 
 .. code-block:: python
 
+    # First import trollius_helper so it is available on Ubuntu with Python 2
+    import osrf_pycommon.vendor.trollius_helper  # noqa
     import trollius as asyncio
     from osrf_pycommon.process_utils import async_execute_process
     from osrf_pycommon.process_utils import AsyncSubprocessProtocol

--- a/osrf_pycommon/process_utils/async_execute_process_trollius.py
+++ b/osrf_pycommon/process_utils/async_execute_process_trollius.py
@@ -16,6 +16,7 @@ import os
 
 # allow module to be importable for --cover-inclusive
 try:
+    import osrf_pycommon.vendor.trollius_helper  # noqa
     import trollius as asyncio
 except ImportError:
     TROLLIUS_FOUND = False

--- a/osrf_pycommon/vendor/trollius_helper/.gitignore
+++ b/osrf_pycommon/vendor/trollius_helper/.gitignore
@@ -1,0 +1,1 @@
+trollius

--- a/osrf_pycommon/vendor/trollius_helper/README.md
+++ b/osrf_pycommon/vendor/trollius_helper/README.md
@@ -1,0 +1,17 @@
+This "trollius" sub-package in the `osrf_pycommon.vendor` package is designed to allow an embedded copy of trollius.
+This is requried when a suitable dependency on trollius cannot be acheived through normal channels.
+For example, on Ubuntu Trusty there is no debian binary package for python-trollius.
+So inorder to release a binary package of osrf_pycommon we need to embed a version of trollius.
+
+For most systems this is not necessary, as osrf_pycommon is installed from pip and trollius can be just a normal dependency.
+
+This sub-package works like so:
+
+- the `__init__.py` file will try to import trollius normally
+- if that fails it will check for an embedded version of trollius
+- if that exists it will add that folder to the path and try to import again
+
+In order for this embedded version to work it must be placed in a folder called `trollius` in this folder.
+It must also have the layout of trollius's source repository as of 2.1, i.e. the importable source is in the root.
+
+By default, the 2.1 release of trollius will be cloned (or fetched and extracted) to this folder before release.

--- a/osrf_pycommon/vendor/trollius_helper/__init__.py
+++ b/osrf_pycommon/vendor/trollius_helper/__init__.py
@@ -1,0 +1,35 @@
+# Copyright 2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Try's to import trollius normally, but will also try to import a local copy.
+
+Should be imported before calling ``import trollius``.
+"""
+
+import os
+import sys
+
+try:
+    import trollius
+except ImportError:
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    trollius_dir = os.path.join(this_dir, 'trollius')
+    if os.path.exists(trollius_dir):
+        sys.path.insert(0, trollius_dir)
+        import trollius
+
+
+def get_trollius_module():
+    return trollius

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,79 @@
+from __future__ import print_function
+
+import os
+import shutil
 import sys
+import urllib
+import zipfile
 
 from setuptools import setup
 from setuptools import find_packages
+
+from distutils.command import clean
+from setuptools.command import build_py
+from setuptools.command import sdist
+
+
+def get_custom_cmdclass():
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    trollius_dir = os.path.join(this_dir, 'osrf_pycommon', 'vendor', 'trollius_helper', 'trollius')
+    trollius_zip = 'trollius-2.1.zip'
+
+    # Function for getting version 2.1 of trollius and embedding it in the vendor sub-package.
+    def setup_embedded_trollius():
+        if not os.path.exists(trollius_zip):
+            url = "https://github.com/haypo/trollius/archive/trollius-2.1.zip"
+            print("Retrieving trollius source from:", url)
+            urllib.urlretrieve(url, trollius_zip)
+
+        if not os.path.exists(trollius_dir):
+            extraction_target = os.path.dirname(trollius_dir)
+            print("Extracting trollius source to:", extraction_target)
+            with zipfile.ZipFile(trollius_zip, 'r') as z:
+                z.extractall(extraction_target)
+            os.rename(os.path.join(extraction_target, 'trollius-trollius-2.1'), trollius_dir)
+
+    def cleanup_embedded_trollius():
+        if os.path.exists(trollius_zip):
+            print("Removing:", trollius_zip)
+            os.remove(trollius_zip)
+        if os.path.exists(trollius_dir):
+            print("Removing:", trollius_dir)
+            shutil.rmtree(trollius_dir)
+
+    # Custom sdist for setuptools which additionally embeds trollius in vendor.
+    # This is only used when packaging a binary for Debian.
+    class CustomSDist(sdist.sdist):
+        def run(self):
+            setup_embedded_trollius()
+            return sdist.sdist.run(self)
+
+    class CustomBuild(build_py.build_py):
+        def finalize_options(self):
+            build_py.build_py.finalize_options(self)
+            trollius_files = []
+            for root, dirnames, filenames in os.walk(trollius_dir):
+                for filename in filenames:
+                    trollius_files.append(os.path.join(root, filename))
+            self.package_data['osrf_pycommon.vendor.trollius_helper'] = trollius_files
+
+    class CustomClean(clean.clean):
+        def run(self):
+            cleanup_embedded_trollius()
+            clean.clean.run(self)
+
+    return {
+        'sdist': CustomSDist,
+        'build_py': CustomBuild,
+        'clean': CustomClean,
+    }
+
+# If either 'sdist_dsc' or 'bdist_deb' are in the args, we're building a .deb.
+building_debian = 'sdist_dsc' in sys.argv or 'bdist_deb' in sys.argv
+cmdclass = {}
+# If Python < 3.4, and packaging for Debian, setup an embedded copy of trollius.
+if sys.version_info < (3, 4) and building_debian:
+    cmdclass = get_custom_cmdclass()
 
 
 install_requires = [
@@ -13,6 +85,7 @@ if sys.version_info < (3, 4):
 setup(
     name='osrf_pycommon',
     version='0.0.0',
+    cmdclass=cmdclass,
     packages=find_packages(exclude=['tests', 'docs']),
     install_requires=install_requires,
     author='William Woodall',


### PR DESCRIPTION
This package will add an embedded version of `trollius` to the `PYTHONPATH` if `trollius` is not found in the system.

It will not always have the embedded version of `trollius`, in which cases it will just fail if `trollius` is not found in the system.

Currently the only target case for embedding `trollius` is when making the Debian binary with `stdeb`. This is done because there is no `trollius` binary for Debian/Ubuntu.

The `setup.py` file has new logic which embeds `trollius` 2.1 when building a `.deb`. This is also avoided for Python versions < 3.4, since `asyncio` is available for all of these.

For motivation, see: https://github.com/osrf/osrf_pycommon/issues/9#issuecomment-186100507