### PR TITLE
add stdeb.cfg release configuration

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,0 +1,5 @@
+[DEFAULT]
+Depends: python-setuptools, python-trollius
+Depends3: python3-setuptools, python3-trollius
+Suite: trusty vivid wily xenial jessie
+X-Python3-Version: >= 3.2


### PR DESCRIPTION
The suite list is limited by the availability of `python-trollius` and `python3-trollius`. It is available in upstream vivid, wily, xenial, and jessie, and we backported it to trusty.