### PR TITLE
Do not install asyncio files for python2

### DIFF
--- a/osrf_pycommon/process_utils/async_execute_process.py
+++ b/osrf_pycommon/process_utils/async_execute_process.py
@@ -14,34 +14,19 @@
 
 from __future__ import print_function
 
-import os
 import sys
 
-try:
+if sys.version_info >= (3, 4):
+    # If using Python 3.4 or greater, asyncio is always available.
+    from .async_execute_process_asyncio import async_execute_process
+    from .async_execute_process_asyncio import get_loop
+    from .async_execute_process_asyncio import asyncio
+else:
     # If Python is < 3.3 then a SyntaxError will occur with asyncio
-    # If Python is 3.3 and asyncio is not installed an ImportError occurs
-    # In both cases, we must try to use trollius first
-    from .async_execute_process_trollius import TROLLIUS_FOUND
-    if not TROLLIUS_FOUND:
-        raise ImportError
+    # so we will use Trollius on all platforms below Python 3.4.
     from .async_execute_process_trollius import async_execute_process
     from .async_execute_process_trollius import get_loop
     from .async_execute_process_trollius import asyncio
-except ImportError as exc:
-    if 'PYTHONASYNCIODEBUG' in os.environ:
-        import traceback
-        traceback.print_exc()
-    # If Trollius is not installed, they we can try asyncio
-    # If Python is >= 3.4 asyncio is included
-    # If Python is == 3.3 asyncio can be installed via pip
-    try:
-        from .async_execute_process_asyncio import async_execute_process
-        from .async_execute_process_asyncio import get_loop
-        from .async_execute_process_asyncio import asyncio
-    except SyntaxError:
-        raise ImportError("No module named trollius and asyncio not supported")
-    except ImportError:
-        raise ImportError("No module named trollius or asyncio")
 
 __all__ = [
     'async_execute_process',

--- a/osrf_pycommon/process_utils/async_execute_process_asyncio/__init__.py
+++ b/osrf_pycommon/process_utils/async_execute_process_asyncio/__init__.py
@@ -1,0 +1,35 @@
+# Copyright 2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    try:
+        import asyncio
+    except ImportError:
+        pass
+    else:
+        from .impl import async_execute_process
+        from .impl import get_loop
+
+        __all__ = [
+            'async_execute_process',
+            'asyncio',
+            'get_loop',
+        ]
+except SyntaxError:
+    pass
+
+"""
+This exists as a package rather than a module so that it can be excluded from
+install in the setup.py when installing for Python2.
+"""

--- a/osrf_pycommon/process_utils/async_execute_process_asyncio/impl.py
+++ b/osrf_pycommon/process_utils/async_execute_process_asyncio/impl.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     has_pty = False
 
-from .get_loop_impl import get_loop_impl
+from ..get_loop_impl import get_loop_impl
 
 
 def get_loop():

--- a/osrf_pycommon/process_utils/async_execute_process_trollius.py
+++ b/osrf_pycommon/process_utils/async_execute_process_trollius.py
@@ -13,14 +13,11 @@
 # limitations under the License.
 
 import os
+import sys
 
-# allow module to be importable for --cover-inclusive
-try:
+# Conditionally import so that nosetest --with-coverge --cover-inclusive works.
+if sys.version_info < (3, 4):
     import trollius as asyncio
-except ImportError:
-    TROLLIUS_FOUND = False
-else:
-    TROLLIUS_FOUND = True
 
     from trollius import From
     from trollius import Return

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,19 @@ install_requires = [
 ]
 if sys.version_info < (3, 4):
     install_requires.append('trollius')
+package_excludes = ['tests*', 'docs*']
+if sys.version_info < (3, ):
+    # On non-Python3 installs, avoid installing the asyncio files
+    # which contain Python3 specific syntax.
+    package_excludes.append(
+        'osrf_pycommon.process_utils.async_execute_process_asyncio'
+    )
+packages = find_packages(exclude=package_excludes)
 
 setup(
     name='osrf_pycommon',
     version='0.1.0',
-    packages=find_packages(exclude=['tests', 'docs']),
+    packages=packages,
     install_requires=install_requires,
     author='William Woodall',
     author_email='william@osrfoundation.org',


### PR DESCRIPTION
This is the solution I've come up with to avoid errors in the post install hook when installing the Python2 debian of this package.

It avoids installing any files which use Python3 specific syntax when installing for Python2.