### PR TITLE
[process_utils] use the trollius loop if trollius has already been imported

### DIFF
--- a/osrf_pycommon/process_utils/async_execute_process.py
+++ b/osrf_pycommon/process_utils/async_execute_process.py
@@ -16,8 +16,9 @@ from __future__ import print_function
 
 import sys
 
-if sys.version_info >= (3, 4):
+if sys.version_info >= (3, 4) and 'trollius' not in sys.modules:
     # If using Python 3.4 or greater, asyncio is always available.
+    # However, if trollius has already been imported, use that.
     from .async_execute_process_asyncio import async_execute_process
     from .async_execute_process_asyncio import get_loop
     from .async_execute_process_asyncio import asyncio

--- a/osrf_pycommon/process_utils/async_execute_process_trollius.py
+++ b/osrf_pycommon/process_utils/async_execute_process_trollius.py
@@ -16,7 +16,7 @@ import os
 import sys
 
 # Conditionally import so that nosetest --with-coverge --cover-inclusive works.
-if sys.version_info < (3, 4):
+if sys.version_info < (3, 4) or 'trollius' in sys.modules:
     import trollius as asyncio
 
     from trollius import From


### PR DESCRIPTION
This is meant to try and solve: https://github.com/catkin/catkin_tools/pull/293#issuecomment-200036885

Basically, if you `import trollius` before using `osrf_pycommon.process_utils` then it will use the trollius version of the "loop" because the trollius loop will support both trollius and asyncio, whereas asyncio does not support trollius.

@jbohren can you try to update the CI on https://github.com/catkin/catkin_tools/pull/293 to test out this change?