### PR TITLE
fix detection of required arguments

### DIFF
--- a/osrf_pycommon/cli_utils/verb_pattern.py
+++ b/osrf_pycommon/cli_utils/verb_pattern.py
@@ -40,9 +40,11 @@ def call_prepare_arguments(func, parser, sysargs=None):
     func_args = [parser]
     # If the provided function takes two arguments and args were given
     # also give the args to the function
-    arguments = inspect.getargspec(func)[0]
+    arguments, _, _, defaults = inspect.getargspec(func)
     if arguments[0] == 'self':
         del arguments[0]
+    if defaults:
+        arguments = arguments[:-len(defaults)]
     if len(arguments) not in [1, 2]:
         raise ValueError("Given function '{0}' must have one or two "
                          "parameters (excluding self), but got '{1}' "

--- a/tests/unit/test_cli_utils/test_verb_pattern.py
+++ b/tests/unit/test_cli_utils/test_verb_pattern.py
@@ -84,6 +84,22 @@ class TestCliUtilsVerbPattern(unittest.TestCase):
         with self.assertRaisesRegexp(ValueError, 'one or two parameters'):
             r = cpa(f.fake_prepare_arguments, None)
 
+        # Try with additional optional argument
+        called = False
+
+        class Foo:
+            def fake_prepare_arguments(self, parser, args, optional=None):
+                global called
+                called = True
+                if called:
+                    pass
+                return parser
+
+        f = Foo()
+        r = cpa(f.fake_prepare_arguments, None)
+        self.assertTrue(called)
+        self.assertIsNone(r)
+
     def test_split_arguments_by_verb(self):
         args = ['--cmd-arg1', 'verb', '--verb-arg1', '--verb-arg2']
         expected = ('verb', ['--cmd-arg1'], ['--verb-arg1', '--verb-arg2'])


### PR DESCRIPTION
Before all arguments were considered required. With this change optional arguments are not counted when the signature length is checked,

This is required for ament/ament_tools#98 (which has already been merged and fails builds without this change).