### PR TITLE
work around hanging issue on Windows

### DIFF
--- a/tests/test_code_format.py
+++ b/tests/test_code_format.py
@@ -8,6 +8,8 @@ def test_flake8():
     this_dir = os.path.dirname(os.path.abspath(__file__))
     source_dir = os.path.join(this_dir, '..', 'osrf_pycommon')
     cmd = ['flake8', source_dir, '--count']
+    # work around for https://gitlab.com/pycqa/flake8/issues/179
+    cmd.extend(['--jobs', '1'])
     if sys.version_info < (3,4):
         # Unless Python3, skip files with new syntax, like `yield from`
         cmd.append('--exclude=*async_execute_process_asyncio/impl.py')


### PR DESCRIPTION
See: https://gitlab.com/pycqa/flake8/issues/179

It originally caused a job to hang on our ros2 build farm: http://ci.ros2.org/job/nightly_win_deb/184/console