### PR TITLE
Add python build dependencies.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>python3</buildtool_depend>
 
-  <buildtool_export_depend>python3</buildtool_export_depend>
+  <exec_depend>python3</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/package.xml
+++ b/package.xml
@@ -7,6 +7,12 @@
   <maintainer email="william@osrfoundation.org">William Woodall</maintainer>
   <license>Apache License 2.0</license>
 
+  <build_depend>python3-setuptools</build_depend>
+
+  <buildtool_depend>python3</buildtool_depend>
+
+  <buildtool_export_depend>python3</buildtool_export_depend>
+
   <export>
     <build_type>ament_python</build_type>
   </export>


### PR DESCRIPTION
In order to be packaged with ament_python + bloom these build dependencies are required.