### PR TITLE
Python dependencies are handled by Bloom/debhelper now.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -7,12 +7,6 @@
   <maintainer email="william@osrfoundation.org">William Woodall</maintainer>
   <license>Apache License 2.0</license>
 
-  <build_depend>python3-setuptools</build_depend>
-
-  <buildtool_depend>python3</buildtool_depend>
-
-  <exec_depend>python3</exec_depend>
-
   <export>
     <build_type>ament_python</build_type>
   </export>


### PR DESCRIPTION
As of https://github.com/ros2/bloom/commit/9aaf39f09d802851ee55eac394f6cd11143b4439 bloom now adds the Debian recommended python build dependencies for packages with the ament_python build type and uses debhelper magic to add `${python3:Depends}` for runtime dependencies. As such, these changes are no longer needed to package osrf_pycommon.

The long term need to explicitly depend on python for python packages can be discussed at a later date.