### PR TITLE
Add I to the list of ignored flake8 errors.

### DIFF
--- a/tests/test_code_format.py
+++ b/tests/test_code_format.py
@@ -15,7 +15,7 @@ def test_flake8():
     except ImportError:
         pass
     # ignore error codes from plugins this package doesn't comply with
-    cmd.extend(['--ignore=C,D,Q'])
+    cmd.extend(['--ignore=C,D,Q,I'])
     # work around for https://gitlab.com/pycqa/flake8/issues/179
     cmd.extend(['--jobs', '1'])
     if sys.version_info < (3, 4):


### PR DESCRIPTION
I202 warns about newlines between groups of imports in python.
A recent change in flake8
(https://github.com/PyCQA/flake8-import-order/commit/37dafcc35eec9343641d489ac01d316cd10a6c03)
made this start showing up in osrf_pycommon.  Since we use whitespace
between imports, disable this warning in this repository.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

CI: in ament/ament_lint#89

connects to ros2/build_cop#67