### PR TITLE
0.1.6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+0.1.6 (2018-11-15 12:45:00 -0800)
+---------------------------------
+- Changed package.xml to use python2 or python3 dependencies as appropriate. `#50 <https://github.com/osrf/osrf_pycommon/pull/50>`_
+
 0.1.5 (2018-06-19 21:00:00 -0800)
 ---------------------------------
 - Fixed a try-catch statement to adapt to changes in asyncio's raise behavior in `asyncio.get_event_loop()`.

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>osrf_pycommon</name>
-  <version>0.1.5</version>
+  <version>0.1.6</version>
   <description>Commonly needed Python modules, used by Python software developed at OSRF.</description>
   <maintainer email="william@osrfoundation.org">William Woodall</maintainer>
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ packages = find_packages(exclude=package_excludes)
 
 setup(
     name='osrf_pycommon',
-    version='0.1.5',
+    version='0.1.6',
     packages=packages,
     install_requires=install_requires,
     zip_safe=True,


### PR DESCRIPTION
:warning: This commit should be fast-forwarded onto master rather than merged via the GitHub UI :warning:

Preparing 0.1.6 release with the latest changes.