### PR TITLE
Use keyword arguments only for protocol_class invocations

### DIFF
--- a/osrf_pycommon/process_utils/async_execute_process_asyncio/impl.py
+++ b/osrf_pycommon/process_utils/async_execute_process_asyncio/impl.py
@@ -65,7 +65,7 @@ if has_pty:
             stderr_master, stderr_slave = pty.openpty()
 
         def protocol_factory():
-            return protocol_class(None, stdout_master, stderr_master)
+            return protocol_class(stdin=None, stdout=stdout_master, stderr=stderr_master)
 
         # Start the subprocess
         if shell is True:

--- a/osrf_pycommon/process_utils/async_execute_process_asyncio/impl.py
+++ b/osrf_pycommon/process_utils/async_execute_process_asyncio/impl.py
@@ -65,7 +65,11 @@ if has_pty:
             stderr_master, stderr_slave = pty.openpty()
 
         def protocol_factory():
-            return protocol_class(stdin=None, stdout=stdout_master, stderr=stderr_master)
+            return protocol_class(
+                stdin=None,
+                stdout=stdout_master,
+                stderr=stderr_master
+            )
 
         # Start the subprocess
         if shell is True:

--- a/osrf_pycommon/process_utils/async_execute_process_trollius.py
+++ b/osrf_pycommon/process_utils/async_execute_process_trollius.py
@@ -69,7 +69,11 @@ if sys.version_info < (3, 4) or 'trollius' in sys.modules:
                 stderr_master, stderr_slave = pty.openpty()
 
             def protocol_factory():
-                return protocol_class(stdin=None, stdout=stdout_master, stderr=stderr_master)
+                return protocol_class(
+                    stdin=None,
+                    stdout=stdout_master,
+                    stderr=stderr_master
+                )
 
             # Start the subprocess
             if shell is True:

--- a/osrf_pycommon/process_utils/async_execute_process_trollius.py
+++ b/osrf_pycommon/process_utils/async_execute_process_trollius.py
@@ -69,7 +69,7 @@ if sys.version_info < (3, 4) or 'trollius' in sys.modules:
                 stderr_master, stderr_slave = pty.openpty()
 
             def protocol_factory():
-                return protocol_class(None, stdout_master, stderr_master)
+                return protocol_class(stdin=None, stdout=stdout_master, stderr=stderr_master)
 
             # Start the subprocess
             if shell is True:

--- a/osrf_pycommon/process_utils/impl.py
+++ b/osrf_pycommon/process_utils/impl.py
@@ -226,8 +226,8 @@ def _which_backport(cmd, mode=os.F_OK | os.X_OK, path=None):
     # Additionally check that `file` is not a directory, as on Windows
     # directories pass the os.access check.
     def _access_check(fn, mode):
-        return (os.path.exists(fn) and os.access(fn, mode) and
-                not os.path.isdir(fn))
+        return (os.path.exists(fn) and os.access(fn, mode) and not
+                os.path.isdir(fn))
 
     # If we're given a path with a directory part, look it up directly rather
     # than referring to PATH directories. This includes checking relative

--- a/tests/unit/test_process_utils/impl_aep_protocol.py
+++ b/tests/unit/test_process_utils/impl_aep_protocol.py
@@ -3,10 +3,10 @@ from osrf_pycommon.process_utils import AsyncSubprocessProtocol
 
 def create_protocol():
     class CustomProtocol(AsyncSubprocessProtocol):
-        def __init__(self, *args, **kwargs):
+        def __init__(self, **kwargs):
             self.stdout_buffer = b""
             self.stderr_buffer = b""
-            AsyncSubprocessProtocol.__init__(self, *args, **kwargs)
+            AsyncSubprocessProtocol.__init__(self, **kwargs)
 
         def on_stdout_received(self, data):
             self.stdout_buffer += data


### PR DESCRIPTION
This bugfixes a problem in [osrf_pycommon/process_utils/async_execute_process_asyncio/impl.py#L67-L68](https://github.com/osrf/osrf_pycommon/blob/1db811bff17400e5e5402ddb6fa1dc786bf63cf5/osrf_pycommon/process_utils/async_execute_process_asyncio/impl.py#L67-L68) which fails when operating on a  protocol class that only uses keyword arguments. 

See [ros2/launch/issues/188](https://github.com/ros2/launch/issues/188#issuecomment-466262043) for more details. The traceback there if tty is enabled, which triggers this code:

```
Traceback (most recent call last):
  File "/opt/ros/crystal/lib/python3.6/site-packages/launch/actions/execute_process.py", line 423, in __execute_process
    stderr_to_stdout=(self.__output == 'screen'),
  File "/opt/ros/crystal/lib/python3.6/site-packages/osrf_pycommon/process_utils/async_execute_process_asyncio/impl.py", line 136, in async_execute_process
    stderr_to_stdout)
  File "/opt/ros/crystal/lib/python3.6/site-packages/osrf_pycommon/process_utils/async_execute_process_asyncio/impl.py", line 78, in _async_execute_process_pty
    stdout=stdout_slave, stderr=stderr_slave, close_fds=False)
  File "/usr/lib/python3.6/asyncio/base_events.py", line 1191, in subprocess_exec
    protocol = protocol_factory()
  File "/opt/ros/crystal/lib/python3.6/site-packages/osrf_pycommon/process_utils/async_execute_process_asyncio/impl.py", line 68, in protocol_factory
    return protocol_class(None, stdout_master, stderr_master)
TypeError: <lambda>() takes 0 positional arguments but 3 were given
```

Since positional ordering does not seem to be relevant here and keyword args are always more readable, I've updated the call to use keywords and the tests to force use of keyword only calls in this PR.
