### PR TITLE
ansi_escape_senquences -> ansi_escape_sequences

### DIFF
--- a/osrf_pycommon/process_utils/impl.py
+++ b/osrf_pycommon/process_utils/impl.py
@@ -122,7 +122,7 @@ def execute_process(cmd, cwd=None, env=None, shell=False, emulate_tty=False):
     If you want to ensure there is no color in the output from an executed
     process, then use this function:
 
-    :py:func:`osrf_pycommon.terminal_color.remove_ansi_escape_senquences`
+    :py:func:`osrf_pycommon.terminal_color.remove_ansi_escape_sequences`
 
     Exceptions can be raised by functions called by the implementation,
     for example, :py:class:`subprocess.Popen` can raise an :py:exc:`OSError`

--- a/osrf_pycommon/terminal_color/__init__.py
+++ b/osrf_pycommon/terminal_color/__init__.py
@@ -146,7 +146,7 @@ which only contain ansi escape sequences.
 
 """
 
-from .ansi_re import remove_ansi_escape_senquences
+from .ansi_re import remove_ansi_escape_sequences
 from .ansi_re import split_by_ansi_escape_sequence
 
 from .impl import ansi
@@ -167,7 +167,7 @@ __all__ = [
     'get_ansi_dict',
     'print_ansi_color_win32',
     'print_color',
-    'remove_ansi_escape_senquences',
+    'remove_ansi_escape_sequences',
     'sanitize',
     'split_by_ansi_escape_sequence',
     'test_colors',

--- a/osrf_pycommon/terminal_color/ansi_re.py
+++ b/osrf_pycommon/terminal_color/ansi_re.py
@@ -38,7 +38,7 @@ def split_by_ansi_escape_sequence(string, include_delimiters=False):
     return _ansi_re.split(string)
 
 
-def remove_ansi_escape_senquences(string):
+def remove_ansi_escape_sequences(string):
     """
     Removes any ansi escape sequences found in the given string and returns it.
     """

--- a/tests/unit/test_terminal_color/test_ansi_re.py
+++ b/tests/unit/test_terminal_color/test_ansi_re.py
@@ -16,12 +16,12 @@ class TestTerminalColorAnsiRe(unittest.TestCase):
         expected = ["", "red ", "bold red ", "normal ", "red bg"]
         self.assertEqual(expected, split_ansi(self.test_str, False))
 
-    def test_remove_ansi_escape_senquences(self):
-        remove_ansi = ansi_re.remove_ansi_escape_senquences
+    def test_remove_ansi_escape_sequences(self):
+        remove_ansi = ansi_re.remove_ansi_escape_sequences
         expected = "red bold red normal red bg"
         self.assertEqual(expected, remove_ansi(self.test_str))
 
-    def test_remove_ansi_escape_senquences_false_positives(self):
-        remove_ansi = ansi_re.remove_ansi_escape_senquences
+    def test_remove_ansi_escape_sequences_false_positives(self):
+        remove_ansi = ansi_re.remove_ansi_escape_sequences
         false_positive = "Should not match: \1xb[1234m \033[m \1xb[3Om"
         self.assertEqual(false_positive, remove_ansi(false_positive))


### PR DESCRIPTION
This does change the name of a public API.  If we are concerned about that, I can instead alias the functions together.