### PR TITLE
Update release suites.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [DEFAULT]
 Depends: python-setuptools, python-trollius
 Depends3: python3-setuptools
-Suite: trusty vivid wily xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
+Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 X-Python3-Version: >= 3.2

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [DEFAULT]
 Depends: python-setuptools, python-trollius
 Depends3: python3-setuptools
-Suite: trusty vivid wily xenial yakkety zesty artful bionic jessie stretch buster
+Suite: trusty vivid wily xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
Cosmic, Disco, and Eoan are now live on the ROS bootstrap repository and future releases should be pushed to them as well.

The second commit removes suites older than Ubuntu Xenial.