### PR TITLE
Also run tests with Python 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "2.7"
   - "3.4"
+  - "3.7"
+  - "3.8"
 install:
   - pip install coverage nose flake8 mock
   - pip install git+https://github.com/PyCQA/flake8-import-order.git


### PR DESCRIPTION
Debian Buster uses Python 3.7 and Ubuntu Focal will use Python 3.8