### PR TITLE
fixed simple deprecation warnings (issue #61)

### DIFF
--- a/osrf_pycommon/cli_utils/verb_pattern.py
+++ b/osrf_pycommon/cli_utils/verb_pattern.py
@@ -49,7 +49,7 @@ def call_prepare_arguments(func, parser, sysargs=None):
         arguments, _, _, defaults = inspect.getargspec(func)
 
     else:
-        arguments, _, _, defaults = inspect.getfullargspec(func)
+        arguments, _, _, defaults, _, _, _ = inspect.getfullargspec(func)
 
     if arguments[0] == 'self':
         del arguments[0]

--- a/osrf_pycommon/cli_utils/verb_pattern.py
+++ b/osrf_pycommon/cli_utils/verb_pattern.py
@@ -14,6 +14,7 @@
 
 """API for implementing commands and verbs which used the verb pattern."""
 
+import sys
 import inspect
 
 import pkg_resources
@@ -41,18 +42,36 @@ def call_prepare_arguments(func, parser, sysargs=None):
     func_args = [parser]
     # If the provided function takes two arguments and args were given
     # also give the args to the function
-    arguments, _, _, defaults = inspect.getargspec(func)
+
+    # Remove the following if condition and keep else condition once Xenial is
+    # dropped
+    if sys.version_info[0] < 3:
+        arguments, _, _, defaults = inspect.getargspec(func)
+
+    else:
+        arguments, _, _, defaults = inspect.getfullargspec(func)
+
     if arguments[0] == 'self':
         del arguments[0]
     if defaults:
         arguments = arguments[:-len(defaults)]
     if len(arguments) not in [1, 2]:
+        # Remove the following if condition once Xenial is dropped
+        if sys.version_info[0] < 3:
+            raise ValueError("Given function '{0}' must have one or two "
+                             "parameters (excluding self), but got '{1}' "
+                             "parameters: '{2}'"
+                             .format(func.__name__,
+                                     len(arguments),
+                                     ', '.join(inspect.getargspec(func)[0])))
+
         raise ValueError("Given function '{0}' must have one or two "
                          "parameters (excluding self), but got '{1}' "
                          "parameters: '{2}'"
                          .format(func.__name__,
                                  len(arguments),
                                  ', '.join(inspect.getfullargspec(func)[0])))
+
     if len(arguments) == 2:
         func_args.append(sysargs or [])
     return func(*func_args) or parser

--- a/osrf_pycommon/cli_utils/verb_pattern.py
+++ b/osrf_pycommon/cli_utils/verb_pattern.py
@@ -52,7 +52,7 @@ def call_prepare_arguments(func, parser, sysargs=None):
                          "parameters: '{2}'"
                          .format(func.__name__,
                                  len(arguments),
-                                 ', '.join(inspect.getargspec(func)[0])))
+                                 ', '.join(inspect.getfullargspec(func)[0])))
     if len(arguments) == 2:
         func_args.append(sysargs or [])
     return func(*func_args) or parser

--- a/tests/unit/test_cli_utils/test_verb_pattern.py
+++ b/tests/unit/test_cli_utils/test_verb_pattern.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 
 from osrf_pycommon.cli_utils import verb_pattern
@@ -66,8 +67,16 @@ class TestCliUtilsVerbPattern(unittest.TestCase):
                 return parser
 
         f = Foo()
-        with self.assertRaisesRegex(ValueError, 'one or two parameters'):
-            r = cpa(f.fake_prepare_arguments, None)
+
+        # Remove the following if condition and keep else condition once
+        # Xenial is dropped
+        if sys.version_info[0] < 3:
+            with self.assertRaisesRegexp(ValueError, 'one or two parameters'):
+                r = cpa(f.fake_prepare_arguments, None)
+
+        else:
+            with self.assertRaisesRegex(ValueError, 'one or two parameters'):
+                r = cpa(f.fake_prepare_arguments, None)
 
         # Try with less than needed
         called = False
@@ -81,8 +90,16 @@ class TestCliUtilsVerbPattern(unittest.TestCase):
                 return 'Should not get here'
 
         f = Foo()
-        with self.assertRaisesRegex(ValueError, 'one or two parameters'):
-            r = cpa(f.fake_prepare_arguments, None)
+
+        # Remove the following if condition and keep else condition once
+        # Xenial is dropped
+        if sys.version_info[0] < 3:
+            with self.assertRaisesRegexp(ValueError, 'one or two parameters'):
+                r = cpa(f.fake_prepare_arguments, None)
+
+        else:
+            with self.assertRaisesRegex(ValueError, 'one or two parameters'):
+                r = cpa(f.fake_prepare_arguments, None)
 
         # Try with additional optional argument
         called = False

--- a/tests/unit/test_cli_utils/test_verb_pattern.py
+++ b/tests/unit/test_cli_utils/test_verb_pattern.py
@@ -81,7 +81,7 @@ class TestCliUtilsVerbPattern(unittest.TestCase):
                 return 'Should not get here'
 
         f = Foo()
-        with self.assertRaisesRegexp(ValueError, 'one or two parameters'):
+        with self.assertRaisesRegex(ValueError, 'one or two parameters'):
             r = cpa(f.fake_prepare_arguments, None)
 
         # Try with additional optional argument

--- a/tests/unit/test_cli_utils/test_verb_pattern.py
+++ b/tests/unit/test_cli_utils/test_verb_pattern.py
@@ -66,7 +66,7 @@ class TestCliUtilsVerbPattern(unittest.TestCase):
                 return parser
 
         f = Foo()
-        with self.assertRaisesRegexp(ValueError, 'one or two parameters'):
+        with self.assertRaisesRegex(ValueError, 'one or two parameters'):
             r = cpa(f.fake_prepare_arguments, None)
 
         # Try with less than needed


### PR DESCRIPTION
Fixed two simple deprecation warnings as outlined in #61. The main deprecation warning, however, requires a bit more work since they have an issue with the `yield` function used within the `async def`.