### PR TITLE
Remove deprecated use of asyncio.coroutine decorator.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
+  - "3.5"
+  - "3.6"
   - "3.7"
   - "3.8"
 install:

--- a/osrf_pycommon/process_utils/async_execute_process_asyncio/impl.py
+++ b/osrf_pycommon/process_utils/async_execute_process_asyncio/impl.py
@@ -28,8 +28,7 @@ def get_loop():
     return get_loop_impl(asyncio)
 
 
-@asyncio.coroutine
-def _async_execute_process_nopty(
+async def _async_execute_process_nopty(
     protocol_class, cmd, cwd, env, shell,
     stderr_to_stdout=True
 ):
@@ -39,11 +38,11 @@ def _async_execute_process_nopty(
         stderr = asyncio.subprocess.STDOUT
     # Start the subprocess
     if shell is True:
-        transport, protocol = yield from loop.subprocess_shell(
+        transport, protocol = await loop.subprocess_shell(
             protocol_class, " ".join(cmd), cwd=cwd, env=env,
             stderr=stderr, close_fds=False)
     else:
-        transport, protocol = yield from loop.subprocess_exec(
+        transport, protocol = await loop.subprocess_exec(
             protocol_class, *cmd, cwd=cwd, env=env,
             stderr=stderr, close_fds=False)
     return transport, protocol
@@ -51,8 +50,7 @@ def _async_execute_process_nopty(
 
 if has_pty:
     # If pty is availabe, use them to emulate the tty
-    @asyncio.coroutine
-    def _async_execute_process_pty(
+    async def _async_execute_process_pty(
         protocol_class, cmd, cwd, env, shell,
         stderr_to_stdout=True
     ):
@@ -73,11 +71,11 @@ if has_pty:
 
         # Start the subprocess
         if shell is True:
-            transport, protocol = yield from loop.subprocess_shell(
+            transport, protocol = await loop.subprocess_shell(
                 protocol_factory, " ".join(cmd), cwd=cwd, env=env,
                 stdout=stdout_slave, stderr=stderr_slave, close_fds=False)
         else:
-            transport, protocol = yield from loop.subprocess_exec(
+            transport, protocol = await loop.subprocess_exec(
                 protocol_factory, *cmd, cwd=cwd, env=env,
                 stdout=stdout_slave, stderr=stderr_slave, close_fds=False)
 
@@ -118,10 +116,10 @@ if has_pty:
         # Also store the transport, protocol tuple for each call to
         # connect_read_pipe, to prevent the destruction of the protocol
         # class instance, otherwise no data is received.
-        protocol.stdout_tuple = yield from loop.connect_read_pipe(
+        protocol.stdout_tuple = await loop.connect_read_pipe(
             PtyStdoutProtocol, os.fdopen(stdout_master, 'rb', 0))
         if not stderr_to_stdout:
-            protocol.stderr_tuple = yield from loop.connect_read_pipe(
+            protocol.stderr_tuple = await loop.connect_read_pipe(
                 PtyStderrProtocol, os.fdopen(stderr_master, 'rb', 0))
         # Return the protocol and transport
         return transport, protocol
@@ -129,17 +127,16 @@ else:
     _async_execute_process_pty = _async_execute_process_nopty
 
 
-@asyncio.coroutine
-def async_execute_process(
+async def async_execute_process(
     protocol_class, cmd=None, cwd=None, env=None, shell=False,
     emulate_tty=False, stderr_to_stdout=True
 ):
     if emulate_tty:
-        transport, protocol = yield from _async_execute_process_pty(
+        transport, protocol = await _async_execute_process_pty(
             protocol_class, cmd, cwd, env, shell,
             stderr_to_stdout)
     else:
-        transport, protocol = yield from _async_execute_process_nopty(
+        transport, protocol = await _async_execute_process_nopty(
             protocol_class, cmd, cwd, env, shell,
             stderr_to_stdout)
     return transport, protocol


### PR DESCRIPTION
In later versions of Python, @asyncio.coroutine is deprecated
in favor of "async def".  However, in order to support python
back to 3.6, we also have to switch from using "yield from"
to instead using "await".

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Note that according to the [Python documentation](https://docs.python.org/3.5/library/asyncio-task.html), this should work all the way back to Python 3.5.  But this definitively breaks support for Python 2, so I've removed it from Travis.