### PR TITLE
Fix the __str__ method for windows terminal_color.

### DIFF
--- a/osrf_pycommon/terminal_color/windows.py
+++ b/osrf_pycommon/terminal_color/windows.py
@@ -224,7 +224,7 @@ else:
 
         def __str__(self):
             return (
-                '({0}, {0}, {0}, {0}, {0}, {0}, {0}, {0}, {0}, {0}, {0})'
+                '({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}, {10})'
                 .format(
                     self.dwSize.Y, self.dwSize.X,
                     self.dwCursorPosition.Y, self.dwCursorPosition.X,


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This started making Travis CI builds fail.  I have no idea why they just started failing now, but in any case this code looks wrong, so this should fix it.