### PR TITLE
Remove use of pkg_resources from osrf_pycommon.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.7"
   - "3.8"
 install:
-  - pip install coverage nose flake8 mock
+  - pip install coverage nose flake8 mock importlib-metadata
   - pip install git+https://github.com/PyCQA/flake8-import-order.git
 script:
   - PYTHONASYNCIODEBUG=1 python setup.py nosetests -s --with-coverage --cover-inclusive

--- a/README.md
+++ b/README.md
@@ -3,4 +3,9 @@ osrf_pycommon
 
 Commonly needed Python modules, used by Python software developed at OSRF.
 
+Branches
+========
+
+If you are releasing (using ``stdeb`` or on the ROS buildfarm) for any Ubuntu < ``focal``, or for any OS that doesn't have a key for ``python3-importlib-metadata``, then you need to use the ``1.0.x`` branch, or the latest ``1.<something>`` branch, because starting with ``2.0.0``, that dependency will be required.
+
 If you are using Python 2, then you should use the ``python2`` branch.

--- a/osrf_pycommon/cli_utils/verb_pattern.py
+++ b/osrf_pycommon/cli_utils/verb_pattern.py
@@ -17,7 +17,7 @@
 import sys
 import inspect
 
-import pkg_resources
+import importlib_metadata
 
 
 def call_prepare_arguments(func, parser, sysargs=None):
@@ -149,7 +149,7 @@ def list_verbs(group):
     :rtype: list of str
     """
     verbs = []
-    for entry_point in pkg_resources.iter_entry_points(group=group):
+    for entry_point in importlib_metadata.entry_points().get(group, []):
         verbs.append(entry_point.name)
     return verbs
 
@@ -162,7 +162,7 @@ def load_verb_description(verb_name, group):
     :returns: verb description
     :rtype: dict
     """
-    for entry_point in pkg_resources.iter_entry_points(group=group):
+    for entry_point in importlib_metadata.entry_points().get(group, []):
         if entry_point.name == verb_name:
             return entry_point.load()
 

--- a/osrf_pycommon/cli_utils/verb_pattern.py
+++ b/osrf_pycommon/cli_utils/verb_pattern.py
@@ -17,7 +17,10 @@
 import sys
 import inspect
 
-import importlib_metadata
+try:
+    import importlib.metadata as importlib_metadata
+except ModuleNotFoundError:
+    import importlib_metadata
 
 
 def call_prepare_arguments(func, parser, sysargs=None):

--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,7 @@
 
   <license>Apache License 2.0</license>
 
+  <exec_depend>python3-importlib-metadata</exec_depend>
   <exec_depend>python3-mock</exec_depend>
 
   <export>

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+import sys
+
 from setuptools import find_packages
 from setuptools import setup
 
@@ -5,6 +7,8 @@ from setuptools import setup
 install_requires = [
     'setuptools',
 ]
+if sys.version_info < (3, 8):
+    install_requires.append('importlib-metadata')
 package_excludes = ['tests*', 'docs*']
 packages = find_packages(exclude=package_excludes)
 

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [DEFAULT]
-Depends3: python3-setuptools
+Depends3: python3-setuptools, python3-importlib-metadata
 Conflicts3: python-osrf-pycommon
 Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal stretch buster
 X-Python3-Version: >= 3.5

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
 Depends3: python3-setuptools, python3-importlib-metadata
 Conflicts3: python-osrf-pycommon
-Suite3: bionic cosmic disco eoan focal jammy buster bullseye
-X-Python3-Version: >= 3.5
+Suite3: focal jammy buster bullseye
+X-Python3-Version: >= 3.8
 No-Python2:


### PR DESCRIPTION
Replace it with the use of the more modern importlib*
libraries.  There are a couple of reasons to do this:

1.  pkg_resources is quite slow to import; on my machine,
just firing up the python interpreter takes ~35ms, while
firing up the python interpreter and importing pkg_resources
takes ~175ms.  Firing up the python interpreter and importing
importlib_metadata takes ~70ms.  Removing 100ms per invocation
of the command-line both makes it speedier for users, and
will speed up our tests (which call out to the command-line
quite a lot).

2.  pkg_resources is somewhat deprecated and being replaced
by importlib.  https://importlib-metadata.readthedocs.io/en/latest/using.html
describes some of it

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

See ros2/ros2#919 for a lot more details on why we want to do this.