### PR TITLE
remove jessie because we no longer support 3.4

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
 Depends: python-setuptools, python-trollius
 Depends3: python3-setuptools
-Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
-Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
+Suite: xenial yakkety zesty artful bionic cosmic disco eoan stretch buster
+Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal stretch buster
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
See: https://github.com/osrf/osrf_pycommon/pull/64#issuecomment-648311606