### PR TITLE
Python 2/3 version conflict

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,7 @@
 [DEFAULT]
 Depends: python-setuptools, python-trollius
 Depends3: python3-setuptools
+Conflicts3: python-osrf-pycommon
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan stretch buster
 Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal stretch buster
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
Both provide the same files. This is needed to upgrade from Ubuntu 18 to
20.