### PR TITLE
Fix osrf.py_common.process_utils.get_loop() implementation

### DIFF
--- a/osrf_pycommon/process_utils/get_loop_impl.py
+++ b/osrf_pycommon/process_utils/get_loop_impl.py
@@ -24,8 +24,15 @@ def get_loop_impl(asyncio):
         return asyncio.get_event_loop()
     # Setup this thread's loop and return it
     if os.name == 'nt':
-        loop = asyncio.ProactorEventLoop()
-        asyncio.set_event_loop(loop)
+        try:
+            loop = asyncio.get_event_loop()
+            if not isinstance(loop, asyncio.ProactorEventLoop):
+                loop.close()  # avoid closing during garbage collection
+                loop = asyncio.ProactorEventLoop()
+                asyncio.set_event_loop(loop)
+        except (RuntimeError, AssertionError):
+            loop = asyncio.ProactorEventLoop()
+            asyncio.set_event_loop(loop)
     else:
         try:
             loop = asyncio.get_event_loop()

--- a/osrf_pycommon/process_utils/get_loop_impl.py
+++ b/osrf_pycommon/process_utils/get_loop_impl.py
@@ -27,7 +27,11 @@ def get_loop_impl(asyncio):
         try:
             loop = asyncio.get_event_loop()
             if not isinstance(loop, asyncio.ProactorEventLoop):
-                loop.close()  # avoid closing during garbage collection
+                # Before replacing the existing loop, explicitly
+                # close it to prevent an implicit close during
+                # garbage collection, which may or may not be a
+                # problem depending on the loop implementation.
+                loop.close()
                 loop = asyncio.ProactorEventLoop()
                 asyncio.set_event_loop(loop)
         except (RuntimeError, AssertionError):


### PR DESCRIPTION
On Windows, avoid loops closing during garbage collection and reuse existing ones if possible.

Connected to https://github.com/ros2/launch/pull/476.