### PR TITLE
add missing conflict to stdeb.cfg

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,7 @@
 [DEFAULT]
 Depends: python-setuptools, python-trollius
 Depends3: python3-setuptools
+Conflicts: python3-osrf-pycommon
 Conflicts3: python-osrf-pycommon
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan stretch buster
 Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal stretch buster


### PR DESCRIPTION
`python-osrf-pycommon` and `python3-osrf-pycommon` should conflict in both directions, currently the conflict is only added to the python 3 package. (They conflict because both install the same `package.xml` and `ament_index` file.)