### PR TITLE
Remove Python3-specific config fields.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
-Depends3: python3-setuptools
-Conflicts3: python-osrf-pycommon
-Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal stretch buster
+Depends: python3-setuptools
+Conflicts: python-osrf-pycommon
+Suite: xenial yakkety zesty artful bionic cosmic disco eoan focal stretch buster
 X-Python3-Version: >= 3.5
 No-Python2:


### PR DESCRIPTION
It's late and I'm afk but if I recall there's an oddity in how py3 vs py2 works for stdeb.
The `3`-suffixed config fields are only used if there's a difference between the python2 and python3 values for those fields. If the base config field is missing, I'm pretty sure that stdeb will use the default values rather than instead look at the `3`-suffixed field.

Since python2 is no longer supported via the No-Python2 field the previously Python3-specific config fields can become the default and only config fields.

Before we merge this I want to verify my recollection regarding the config behavior of stdeb (and test this since I wrote it in the GitHub UI on my phone.