### PR TITLE
Update release distributions.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
 Depends3: python3-setuptools
 Conflicts3: python-osrf-pycommon
-Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal stretch buster
+Suite3: bionic cosmic disco eoan focal jammy buster bullseye
 X-Python3-Version: >= 3.5
 No-Python2:


### PR DESCRIPTION
* Drop Ubuntu Xenial and surrounding non-LTS distributions
* Drop Debian Stretch which is no longer supported upstream
* Add Debian Bullseye
* Add Ubuntu Jammy