### PR TITLE
limit 1.0.x to < focal, due to new dependency available in >= focal only

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,9 @@ osrf_pycommon
 
 Commonly needed Python modules, used by Python software developed at OSRF.
 
+Branches
+========
+
+If you are releasing (using ``stdeb`` or on the ROS buildfarm) for any Ubuntu < ``focal``, or for any OS that doesn't have a key for ``python3-importlib-metadata``, then you need to use the ``1.0.x`` branch, or the latest ``1.<something>`` branch, because starting with ``2.0.0``, that dependency will be required.
+
 If you are using Python 2, then you should use the ``python2`` branch.

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
 Depends3: python3-setuptools
 Conflicts3: python-osrf-pycommon
-Suite3: bionic cosmic disco eoan focal jammy buster bullseye
+Suite3: bionic cosmic disco eoan
 X-Python3-Version: >= 3.5
 No-Python2:


### PR DESCRIPTION
Related to https://github.com/osrf/osrf_pycommon/pull/66