### PR TITLE
Continue releasing 1.0.x on Debian Buster.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
 Depends3: python3-setuptools
 Conflicts3: python-osrf-pycommon
-Suite3: bionic cosmic disco eoan
+Suite3: bionic cosmic disco eoan buster
 X-Python3-Version: >= 3.5
 No-Python2:


### PR DESCRIPTION
Debian Buster is still on Python 3.7: https://packages.debian.org/buster/python3
and thus is not supported by the 2.x releases.