### PR TITLE
Don't release 2.x / master on Debian Buster.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
 Depends3: python3-setuptools, python3-importlib-metadata
 Conflicts3: python-osrf-pycommon
-Suite3: focal jammy buster bullseye
+Suite3: focal jammy bullseye
 X-Python3-Version: >= 3.8
 No-Python2:


### PR DESCRIPTION
Debian Buster is on Python 3.7: https://packages.debian.org/buster/python3

In order to complete this I believe we'll also need to yank osrf-pycommon 2.0.0-1 from the bootstrap ROS and ROS 2 repositories unless we decide to add a Debian epoch which I think is unnecessary.