### PR TITLE
Declare test dependencies in [test] extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,13 @@ setup(
             ['resource/' + package_name]),
     ],
     install_requires=install_requires,
+    extras_require={
+        'test': [
+            'flake8',
+            'flake8_import_order',
+            'pytest',
+        ],
+    },
     python_requires='>=3.5',
     zip_safe=True,
     author='William Woodall',


### PR DESCRIPTION
Adding a test dependency on 'pytest' will cause colcon to use pytest when running the package's tests, which yields a better experience than the existing fallback to unittest.