### PR TITLE
Add bookworm as a python3 target

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
 Depends3: python3-setuptools, python3-importlib-metadata
 Conflicts3: python-osrf-pycommon
-Suite3: focal jammy bullseye
+Suite3: focal jammy bullseye bookworm
 X-Python3-Version: >= 3.8
 No-Python2:


### PR DESCRIPTION
This will need a release or manual flood to deploy.