### PR TITLE
Catch all of the spurious warnings from get_event_loop.

### DIFF
--- a/osrf_pycommon/process_utils/get_loop_impl.py
+++ b/osrf_pycommon/process_utils/get_loop_impl.py
@@ -20,42 +20,43 @@ _thread_local = threading.local()
 
 
 def get_loop_impl(asyncio):
-    global _thread_local
-    if getattr(_thread_local, 'loop_has_been_setup', False):
-        return asyncio.get_event_loop()
-    # Setup this thread's loop and return it
-    if os.name == 'nt':
-        try:
-            loop = asyncio.get_event_loop()
-            if not isinstance(loop, asyncio.ProactorEventLoop):
-                # Before replacing the existing loop, explicitly
-                # close it to prevent an implicit close during
-                # garbage collection, which may or may not be a
-                # problem depending on the loop implementation.
-                loop.close()
+    # See the note in
+    # https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop # noqa
+    # In short, between Python 3.10.0 and 3.10.8, this unconditionally raises a
+    # DeprecationWarning.  But after 3.10.8, it only raises the warning if
+    # ther eis no current loop set in the policy.  Since we are setting a loop
+    # in the policy, this warning is spurious, and will go away once we get
+    # away from Python 3.10.6 (verified with Python 3.11.3).
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            'ignore',
+            'There is no current event loop',
+            DeprecationWarning)
+
+        global _thread_local
+        if getattr(_thread_local, 'loop_has_been_setup', False):
+            return asyncio.get_event_loop()
+        # Setup this thread's loop and return it
+        if os.name == 'nt':
+            try:
+                loop = asyncio.get_event_loop()
+                if not isinstance(loop, asyncio.ProactorEventLoop):
+                    # Before replacing the existing loop, explicitly
+                    # close it to prevent an implicit close during
+                    # garbage collection, which may or may not be a
+                    # problem depending on the loop implementation.
+                    loop.close()
+                    loop = asyncio.ProactorEventLoop()
+                    asyncio.set_event_loop(loop)
+            except (RuntimeError, AssertionError):
                 loop = asyncio.ProactorEventLoop()
                 asyncio.set_event_loop(loop)
-        except (RuntimeError, AssertionError):
-            loop = asyncio.ProactorEventLoop()
-            asyncio.set_event_loop(loop)
-    else:
-        try:
-            # See the note in
-            # https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop # noqa
-            # In short, between Python 3.10.0 and 3.10.8, this unconditionally
-            # raises a DeprecationWarning.  But after 3.10.8, it only raises a
-            # the warning if there is no current loop set in the policy.
-            # Since we are setting a loop in the policy, this warning is
-            # spurious, and will go away once we get away from Python 3.10.6
-            # (verified with Python 3.11.3).
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    'ignore',
-                    'There is no current event loop',
-                    DeprecationWarning)
+        else:
+            try:
                 loop = asyncio.get_event_loop()
-        except (RuntimeError, AssertionError):
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-    _thread_local.loop_has_been_setup = True
+            except (RuntimeError, AssertionError):
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+        _thread_local.loop_has_been_setup = True
+
     return loop


### PR DESCRIPTION
The previous patch that did this only did it for one of the cases, but we actually need to catch this warning for all cases of get_event_loop().  Do that here by wrapping the entire block in catch_warnings().  With this in place, other spurious warnings from downstream packages (like launch) are also quieted.

@cottsay @Voldivh FYI