### PR TITLE
Update deb platforms for release

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
 Depends3: python3-setuptools, python3-importlib-metadata
 Conflicts3: python-osrf-pycommon
-Suite3: focal jammy bullseye bookworm
+Suite3: focal jammy noble bookworm trixie
 X-Python3-Version: >= 3.8
 No-Python2:


### PR DESCRIPTION
Added:
* Ubuntu Noble (24.04 LTS pre-release)
* Debian Trixie (testing)

Dropped:
* Debian Bullseye (oldstable)

Retained:
* Debian Bookworm (stable)
* Ubuntu Focal (20.04 LTS)
* Ubuntu Jammy (22.04 LTS)