### PR TITLE
Align stdeb dependencies with setup.py

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
-Depends3: python3-setuptools, python3-importlib-metadata
+Depends3: python3 (>= 3.8) | python3-importlib-metadata
 Conflicts3: python-osrf-pycommon
 Suite3: focal jammy noble bookworm trixie
-X-Python3-Version: >= 3.8
+X-Python3-Version: >= 3.5
 No-Python2:


### PR DESCRIPTION
Regardless of what suites we target, it would be nice if the same requirements were expressed in both metadata formats.

Follow-up to #81 and #66