### PR TITLE
Add '+upstream' suffix to published deb version

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -4,3 +4,4 @@ Conflicts3: python-osrf-pycommon
 Suite3: focal jammy noble bookworm trixie
 X-Python3-Version: >= 3.8
 No-Python2:
+Upstream-Version-Suffix: +upstream


### PR DESCRIPTION
I'd like to get ahead of these issues instead of rushing to mitigate them when things go awry.

Using a debian version suffix which falls late alphabetically appears to give our packages preference by apt. If a user enables a repository which distributes packages created by OSRF or ROS, it is likely that they wish to use these packages instead of the ones packaged by their platform.

Requires ros-infrastructure/ros_release_python#42