### PR TITLE
Fix typo in verbs help output

### DIFF
--- a/osrf_pycommon/cli_utils/verb_pattern.py
+++ b/osrf_pycommon/cli_utils/verb_pattern.py
@@ -109,7 +109,7 @@ def create_subparsers(parser, cmd_name, verbs, group, sysargs, title=None):
     subparser = parser.add_subparsers(
         title=title or '{0} command'.format(cmd_name),
         metavar=metavar,
-        description='Call `{0} {1} -h` for help on a each verb.'.format(
+        description='Call `{0} {1} -h` for help on each verb.'.format(
             cmd_name, metavar),
         dest='verb'
     )


### PR DESCRIPTION
After 11 years: https://github.com/osrf/osrf_pycommon/blame/94b0d8e89a4000db8bee7b1c70dd8772a20b6229/osrf_pycommon/cli_utils/verb_pattern.py#L112