### PR TITLE
Fix setuptools deprecations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,4 @@ setup(
     description="Commonly needed Python modules, "
                 "used by Python software developed at OSRF",
     license='Apache 2.0',
-    extras_require={
-        'test': [
-            'pytest',
-        ],
-    },
 )

--- a/setup.py
+++ b/setup.py
@@ -42,4 +42,5 @@ setup(
     description="Commonly needed Python modules, "
                 "used by Python software developed at OSRF",
     license='Apache 2.0',
+    test_suite='tests',
 )

--- a/setup.py
+++ b/setup.py
@@ -37,11 +37,14 @@ setup(
     keywords=['osrf', 'utilities'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
     ],
     description="Commonly needed Python modules, "
                 "used by Python software developed at OSRF",
     license='Apache 2.0',
-    test_suite='tests',
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
 )


### PR DESCRIPTION
FIX:


#SetuptoolsDeprecationWarning: License classifiers are deprecated. !!

******************************************************************************** Please consider removing the following classifiers in favor of a SPDX license expression:

License :: OSI Approved :: Apache Software License

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details. ********************************************************************************