### PR TITLE
Drop importlib-metadata from package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,8 +13,6 @@
 
   <author email="william@osrfoundation.org">William Woodall</author>
 
-  <exec_depend>python3-importlib-metadata</exec_depend>
-
   <export>
     <build_type>ament_python</build_type>
   </export>


### PR DESCRIPTION
`rolling` no longer needs this since `rolling` uses python3.9+. I know this package is used around bootstrapping so if the dependency needs to stay until `humble` support is dropped just let me know and will close for now.